### PR TITLE
close parentheses correctly

### DIFF
--- a/demo/icon-toggle-demo.html
+++ b/demo/icon-toggle-demo.html
@@ -10,21 +10,21 @@
         font-family: sans-serif;
       };
     </style>
-  
+
     <h3>Statically-configured icon-toggles</h3>
-    
+
     <icon-toggle toggle-icon="star"></icon-toggle>
     <icon-toggle toggle-icon="star" pressed></icon-toggle>
-    
+
     <h3>Data-bound icon-toggle</h3>
 
     <!-- use a computed binding to generate the message -->
     <div><span>[[message(isFav)]]</span></div>
 
-    <!-- curly brackets ({{}}} allow two-way binding --> 
+    <!-- curly brackets ({{}}) allow two-way binding -->
     <icon-toggle toggle-icon="favorite" pressed="{{isFav}}"></icon-toggle>
   </template>
-  
+
   <script>
     Polymer({
       is: "icon-toggle-demo",


### PR DESCRIPTION
Replaced a curly brace with a parenthesis.
Not sure why my text editor is also modifying the spacing/return characters.